### PR TITLE
Packaging: s/arm/nyx/g

### DIFF
--- a/build/debian/README.source
+++ b/build/debian/README.source
@@ -1,6 +1,6 @@
 To rebuild this deb run the following...
 
-git clone git://git.torproject.org/arm.git
+git clone https://github.com/torproject/nyx.git
 cd arm
 git checkout -b release remotes/origin/release
 git checkout -b packaging remotes/origin/packaging

--- a/build/debian/control
+++ b/build/debian/control
@@ -1,4 +1,4 @@
-Source: tor-arm
+Source: nyx
 Section: comm
 Priority: extra
 Maintainer: Damian Johnson <atagar@torproject.org>
@@ -6,20 +6,20 @@ Uploaders: Ulises Vitulli <dererk@debian.org>
 Build-Depends: debhelper (>= 5), python-support (>= 0.6), cdbs (>= 0.4.49), python
 Standards-Version: 3.9.2.0
 XS-Python-Version: >= 2.5
-Vcs-Git: git://git.torproject.org/arm.git
-Vcs-Browser: https://gitweb.torproject.org/arm.git
-Homepage: http://www.atagar.com/arm/
+Vcs-Git: git://github.com/torproject/nyx.git
+Vcs-Browser: https://github.com/torproject/nyx.git
+Homepage: https://nyx.torproject.org/
 
-Package: tor-arm
+Package: nyx
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-torctl
 Suggests: tor
 XB-Python-Version: ${python:Versions}
 Description: terminal status monitor for tor
- The anonymizing relay monitor (arm) is a terminal status monitor for Tor
- relays, intended for command-line aficionados, ssh connections, and anyone
- stuck with a tty terminal. This works much like top does for system usage,
- providing real time statistics for:
+ Nyx, f/k/a the anonymizing relay monitor (arm), is a terminal status monitor
+ for Tor relays, intended for command-line aficionados, ssh connections, and
+ anyone stuck with a tty terminal. This works much like top does for system
+ usage, providing real time statistics for:
  .
   - bandwidth, cpu, and memory usage
   - relay's current configuration

--- a/build/debian/copyright
+++ b/build/debian/copyright
@@ -1,7 +1,7 @@
 This package was debianized by Damian Johnson <atagar@torproject.org>
 Tue, 08 Jun 2010 19:06:24 +0200
 
-It was downloaded from: http://www.atagar.com/arm
+It was downloaded from: https://nyx.torproject.org/
 
 Upstream Authors:
                     Damian Johnson <atagar@torproject.org>

--- a/build/debian/rules
+++ b/build/debian/rules
@@ -5,8 +5,8 @@ DEB_PYTHON_SYSTEM := pysupport
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/python-distutils.mk
-DEB_PYTHON_PRIVATE_MODULES_DIRS += /usr/share/arm
+DEB_PYTHON_PRIVATE_MODULES_DIRS += /usr/share/nyx
 
-binary-post-install/tor-arm::
-	find debian/tor-arm -name 'arm-*egg-info' -exec rm -v '{}' +
+binary-post-install/nyx::
+	find debian/nyx -name 'nyx-*egg-info' -exec rm -v '{}' +
 

--- a/build/redhat/MANIFEST
+++ b/build/redhat/MANIFEST
@@ -1,5 +1,5 @@
-arm
-armrc.sample
+nyx
+config.sample
 ChangeLog
 install
 LICENSE
@@ -65,7 +65,7 @@ src/cli/menu/actions.py
 src/cli/menu/__init__.py
 src/cli/menu/item.py
 src/cli/menu/menu.py
-src/gui/arm.xml
+src/gui/nyx.xml
 src/gui/configPanel.py
 src/gui/controller.py
 src/gui/generalPanel.py
@@ -94,7 +94,7 @@ src/util/torConfig.py
 src/util/torInterpretor.py
 src/util/torTools.py
 src/util/uiTools.py
-src/resources/arm.1
+src/resources/nyx.1
 src/resources/startTor
 src/resources/torConfigDesc.txt
 src/resources/torrcTemplate.txt

--- a/deb-prep.sh
+++ b/deb-prep.sh
@@ -16,7 +16,7 @@
 
 if [ $# -lt 1 ]
   then
-    echo "Usage: ./deb-prep.sh <arm version>"
+    echo "Usage: ./deb-prep.sh <nyx version>"
     exit 1
   else debVersion=$1
 fi
@@ -24,12 +24,12 @@ fi
 mkdir release_deb
 git archive --format=tar release | (cd ./release_deb && tar xf -)
 
-# edits the man page path for the sample armrc to reflect where it's located
+# edits the man page path for the sample nyxconfig to reflect where it's located
 # on debian:
-# /usr/share/doc/arm/armrc.sample -> /usr/share/doc/tor-arm/armrc.sample.gz
-sed -i 's/\/usr\/share\/doc\/arm\/armrc.sample/\/usr\/share\/doc\/tor-arm\/armrc.sample.gz/g' release_deb/src/resources/arm.1
+# /usr/share/doc/nyx/config.sample -> /usr/share/doc/nyx/config.sample.gz
+sed -i 's/\/usr\/share\/doc\/nyx\/config.sample/\/usr\/share\/doc\/nyx\/config.sample.gz/g' release_deb/src/resources/nyx.1
 
-tar czf tor-arm_${debVersion}.orig.tar.gz release_deb
+tar czf nyx_${debVersion}.orig.tar.gz release_deb
 
 (cd build && git archive --format=tar packaging debian) | (cd ./release_deb && tar xf -)
 

--- a/export.sh
+++ b/export.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# Exports a copy of arm's release branch to the given location. This copy is
+# Exports a copy of nyx's release branch to the given location. This copy is
 # stripped of git metadata and includes a bundled copy of TorCtl and cagraph.
 # This accepts an optional argument for where to place the export.
 
 if [ $# -lt 1 ]
-  then exportDst="./arm"
+  then exportDst="./nyx"
   else exportDst=$1
 fi
 
@@ -15,7 +15,7 @@ then
   exit 1
 fi
 
-# exports arm's release branch
+# exports nyx's release branch
 mkdir $exportDst
 git archive --format=tar release | (cd $exportDst && tar xf -)
 
@@ -39,11 +39,11 @@ rm torctl.tar.gz
 #torctlDir="$(mktemp -d)"
 #git clone git://git.torproject.org/pytorctl.git $torctlDir > /dev/null
 
-# exports torctl to the arm directory
+# exports torctl to the nyx directory
 #(cd $torctlDir && git archive --format=tar --prefix=TorCtl/ master) | (cd $exportDst/src && tar xf - 2> /dev/null)
 
 # cleans up the temporary torctl repo
 #rm -rf torctlDir
 
-echo "arm exported to $exportDst"
+echo "nyx exported to $exportDst"
 


### PR DESCRIPTION
All packaging docs have outdated references to `arm`