### PR TITLE
nyxrc.sample: specify defaults inline

### DIFF
--- a/web/nyxrc.sample
+++ b/web/nyxrc.sample
@@ -21,24 +21,25 @@ connection_rate 5       # Seconds between querying connections.
 resource_rate 5         # Seconds between querying process resource usage.
 port_usage_rate 5       # Seconds between querying processes using ports.
 
-logged_events events    # Events that are shown by default in the log. [2]
+logged_events NOTICE, WARN, ERR, NYX_NOTICE, NYX_WARNING, NYX_ERROR
+                        # Events that are shown by default in the log.
 deduplicate_log true    # Hides duplicate log messages.
 prepopulate_log true    # Populates with events that occure before we started.
 logging_filter pattern  # Regex filter for log messages that are shown. (*)
 write_logs_to /path     # Writes events that occure while running here. (*)
 max_log_size 1000       # Maximum number of log entries.
 
-graph_stat bandwidth        # Statistic to be graphed. [3]
-graph_interval each second  # Graph sampling interval. [4]
-graph_bound max_local       # Bounding for the graph min and max. [5]
+graph_stat bandwidth        # Statistic to be graphed. [2]
+graph_interval each second  # Graph sampling interval. [3]
+graph_bound max_local       # Bounding for the graph min and max. [4]
 graph_height 7              # Height of the graph.
 max_graph_width 300         # Maximum number of samplings.
 
-config_order order          # Order for tor config options. [6]
+config_order MAN_PAGE_ENTRY, NAME, IS_SET # Order for tor config options. [5]
 show_private_options false  # Shows configurations with a '__option' prefix.
 show_virtual_options false  # Shows unsettable tor configurations.
 
-connection_order order  # Order for connections. [7]
+connection_order CATEGORY, IP_ADDRESS, UPTIME # Order for connections. [6]
 resolve_processes true  # Shows processes for SOCKS and CONTROL connections.
 show_addresses true     # Shows addresses of connections.
 
@@ -55,31 +56,25 @@ show_interpreter true   # Shows the control interpreter.
 #
 #   'none" means "use the default color that the developers picked".
 #
-#   Default is: none
-#
-# [2] logged_events is a comma separated list. Default value is...
-#
-#       NOTICE, WARN, ERR, NYX_NOTICE, NYX_WARNING, NYX_ERROR
-#
-# [3] graph_stat options include...
+# [2] graph_stat options include...
 #
 #       none - hide the graph
 #       bandwidth - bandwidth rate downloaded/uploaded
 #       connections- number of connections inbound/outbound
 #       resources - cpu/memory usage of tor
 #
-# [4] graph_interval options include...
+# [3] graph_interval options include...
 #
 #       each second,   5 seconds,     30 seconds,  minutely,
 #       15 minute,     30 minute,     hourly,      daily
 #
-# [5] graph_bound options include...
+# [4] graph_bound options include...
 #
 #       global_max - global maximum (highest value ever seen)
 #       local_max - local maximum (highest value currently on the graph)
 #       tight - local maximum and minimum
 #
-# [6] config_order is three comma separated values that can include...
+# [5] config_order is three comma separated values that can include...
 #
 #       * NAME
 #       * VALUE
@@ -91,9 +86,7 @@ show_interpreter true   # Shows the control interpreter.
 #       * MAN_PAGE_ENTRY
 #       * IS_SET
 #
-#     Default is: MAN_PAGE_ENTRY, NAME, IS_SET
-#
-# [7] connection_order is three comma separated values that can include...
+# [6] connection_order is three comma separated values that can include...
 #
 #       * CATEGORY
 #       * UPTIME
@@ -102,5 +95,3 @@ show_interpreter true   # Shows the control interpreter.
 #       * FINGERPRINT
 #       * NICKNAME
 #       * COUNTRY
-#
-#     Default is: CATEGORY, IP_ADDRESS, UPTIME


### PR DESCRIPTION
This allows the user to simply copy the config and start Nyx. Prior to
this commit, Nyx won't start in that case, because some of the settings
had placeholders instead of their actual defaults.