### PR TITLE
Replace inspect.getargspec usage to support python 3.11

### DIFF
--- a/nyx/panel/__init__.py
+++ b/nyx/panel/__init__.py
@@ -78,7 +78,7 @@ class KeyHandler(collections.namedtuple('Help', ['key', 'description', 'current'
       is_match = self._key_func(key) if self._key_func else key.match(self.key)
 
       if is_match:
-        if inspect.getargspec(self._action).args == ['key']:
+        if inspect.getfullargspec(self._action).args == ['key']:
           self._action(key)
         else:
           self._action()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -94,7 +94,7 @@ def render(func, *args, **kwargs):
     nyx.curses.CURSES_SCREEN.erase()
     start_time = time.time()
 
-    func_args = inspect.getargspec(func).args
+    func_args = inspect.getfullargspec(func).args
 
     if func_args[:1] == ['subwindow'] or func_args[:2] == ['self', 'subwindow']:
       def _draw(subwindow):


### PR DESCRIPTION
Replace all the uses of the deprecated method `inspect.getargspec` with `inspect.getfullargspec` to support Python 3.11

https://bugs.python.org/issue45320
https://docs.python.org/3.11/whatsnew/3.11.html